### PR TITLE
Investiguer les erreurs de connexion terensys

### DIFF
--- a/SOLUTION_SUMMARY.md
+++ b/SOLUTION_SUMMARY.md
@@ -1,0 +1,185 @@
+# terensys.fr Website Issues - Complete Solution Guide
+
+## 🔍 **Confirmed Issues**
+
+1. ✅ **INFINITE REDIRECT LOOP**: `https://www.terensys.fr/` redirects to itself indefinitely
+2. ✅ **SSL CERTIFICATE ISSUES**: `https://terensys.fr/` has TLS connection problems  
+3. ✅ **MAXREDIRECTS ERRORS**: Browser/client applications hitting redirect limits
+4. ✅ **EPROTO ERRORS**: Protocol errors on non-www domain
+
+**Server Details:**
+- IP: 188.165.192.106
+- Stack: Caddy (proxy) + Apache/2.4.52 (Ubuntu)
+- Current Status: Both domains affected
+
+---
+
+## 🚨 **Immediate Action Required**
+
+### **Root Cause**
+The server has a redirect rule that redirects `https://www.terensys.fr/` back to `https://www.terensys.fr/`, creating an infinite loop.
+
+### **Evidence**
+```bash
+curl -I -L --max-redirs 10 https://www.terensys.fr/
+# Shows 10 identical 301 redirects, all pointing to the same URL
+```
+
+---
+
+## 🛠️ **Solution Options**
+
+### **Option 1: Fix Apache .htaccess (Recommended)**
+
+Replace the current `.htaccess` file with the corrected version:
+
+```apache
+RewriteEngine On
+
+# Force HTTPS
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+# Force www (redirect non-www to www)
+RewriteCond %{HTTP_HOST} ^terensys\.fr$ [NC]
+RewriteRule ^(.*)$ https://www.terensys.fr/$1 [R=301,L]
+
+# Remove trailing slashes to prevent loops
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.+)/$ /$1 [R=301,L]
+
+# CRITICAL: Remove any rules like this:
+# RewriteRule ^(.*)$ https://www.terensys.fr/ [R=301,L]
+```
+
+### **Option 2: Fix Caddy Configuration**
+
+Update the Caddy config file (usually `/etc/caddy/Caddyfile`):
+
+```caddy
+# Redirect non-www to www
+terensys.fr {
+    redir https://www.terensys.fr{uri} permanent
+}
+
+# Redirect HTTP to HTTPS
+http://www.terensys.fr {
+    redir https://www.terensys.fr{uri} permanent
+}
+
+# Main site
+www.terensys.fr {
+    tls {
+        protocols tls1.2 tls1.3
+    }
+    
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "SAMEORIGIN"
+    }
+    
+    # Choose one:
+    root * /var/www/html           # For static files
+    # reverse_proxy localhost:8080 # For Apache backend
+    file_server
+}
+```
+
+---
+
+## 📋 **Step-by-Step Fix Process**
+
+### **Step 1: Backup Current Configuration**
+```bash
+# Backup Apache config
+cp /var/www/html/.htaccess /var/www/html/.htaccess.backup
+
+# Backup Caddy config  
+cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.backup
+```
+
+### **Step 2: Identify the Problem Rule**
+Look for rules like this that cause the loop:
+```apache
+RewriteRule ^(.*)$ https://www.terensys.fr/ [R=301,L]
+```
+This redirects everything to the root URL with trailing slash, causing the loop.
+
+### **Step 3: Apply the Fix**
+- **For Apache**: Update `.htaccess` with the corrected rules
+- **For Caddy**: Update `Caddyfile` with the corrected configuration
+
+### **Step 4: Reload Configuration**
+```bash
+# For Apache
+systemctl reload apache2
+
+# For Caddy
+systemctl reload caddy
+```
+
+### **Step 5: Test the Fix**
+```bash
+# Should show successful response (200) with no redirect loop
+curl -I -L --max-redirs 5 https://www.terensys.fr/
+
+# Should redirect to www version
+curl -I -L --max-redirs 5 https://terensys.fr/
+
+# Detailed test
+curl -s -o /dev/null -w "Status: %{http_code}\nFinal URL: %{url_effective}\nRedirects: %{num_redirects}\n" https://www.terensys.fr/
+```
+
+---
+
+## ✅ **Expected Results After Fix**
+
+| URL | Expected Behavior |
+|-----|------------------|
+| `http://terensys.fr/` | 301 → `https://www.terensys.fr/` |
+| `https://terensys.fr/` | 301 → `https://www.terensys.fr/` |
+| `http://www.terensys.fr/` | 308 → `https://www.terensys.fr/` |
+| `https://www.terensys.fr/` | 200 (final destination) |
+
+---
+
+## 🔄 **Verification Commands**
+
+```bash
+# Test all URL variations
+curl -I -L --max-redirs 3 http://terensys.fr/
+curl -I -L --max-redirs 3 https://terensys.fr/
+curl -I -L --max-redirs 3 http://www.terensys.fr/
+curl -I -L --max-redirs 3 https://www.terensys.fr/
+
+# Get detailed response info
+curl -s -o /dev/null -w "HTTP %{http_code} | Redirects: %{num_redirects} | Final: %{url_effective}\n" https://www.terensys.fr/
+```
+
+---
+
+## 🚀 **Priority Level: CRITICAL**
+
+This issue prevents the website from loading completely and affects:
+- ❌ User experience (site completely inaccessible)
+- ❌ SEO rankings (search engines can't index)
+- ❌ Business operations (lost traffic and customers)
+- ❌ SSL security (certificate issues on non-www)
+
+**Estimated Fix Time:** 15-30 minutes once server access is available.
+
+---
+
+## 📞 **Need Help?**
+
+If you need assistance implementing these fixes:
+1. Check server access permissions
+2. Verify which configuration system is primary (Apache vs Caddy)
+3. Test in staging environment first if available
+4. Monitor logs during implementation
+
+**Files to check:**
+- `/var/www/html/.htaccess` (Apache)
+- `/etc/caddy/Caddyfile` (Caddy)
+- Apache virtual host configs in `/etc/apache2/sites-available/`

--- a/caddy_config_fix.txt
+++ b/caddy_config_fix.txt
@@ -1,0 +1,65 @@
+# CORRECTED Caddy configuration for terensys.fr
+# This fixes both the redirect loop and SSL issues
+
+# Handle non-www to www redirect
+terensys.fr {
+    redir https://www.terensys.fr{uri} permanent
+}
+
+# Handle HTTP to HTTPS redirect for www
+http://www.terensys.fr {
+    redir https://www.terensys.fr{uri} permanent
+}
+
+# Main site configuration
+www.terensys.fr {
+    # Enable automatic HTTPS with Let's Encrypt
+    tls {
+        protocols tls1.2 tls1.3
+    }
+    
+    # Security headers
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "SAMEORIGIN"
+        X-XSS-Protection "1; mode=block"
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+    
+    # Serve files or proxy to backend
+    # Option 1: Serve static files
+    root * /var/www/html
+    file_server
+    
+    # Option 2: Proxy to backend (uncomment if using Apache backend)
+    # reverse_proxy localhost:8080
+    
+    # Optional: Error handling
+    handle_errors {
+        @404 {
+            expression {http.error.status_code} == 404
+        }
+        rewrite @404 /404.html
+        file_server
+    }
+}
+
+# Alternative single-block configuration (if you prefer):
+# terensys.fr, www.terensys.fr {
+#     @nonwww host terensys.fr
+#     redir @nonwww https://www.terensys.fr{uri} permanent
+#     
+#     tls {
+#         protocols tls1.2 tls1.3
+#     }
+#     
+#     header {
+#         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+#         X-Content-Type-Options "nosniff"
+#         X-Frame-Options "SAMEORIGIN"
+#     }
+#     
+#     root * /var/www/html
+#     file_server
+# }

--- a/htaccess_fix.txt
+++ b/htaccess_fix.txt
@@ -1,0 +1,32 @@
+# CORRECTED .htaccess file for terensys.fr
+# This fixes the infinite redirect loop
+
+RewriteEngine On
+
+# 1. Force HTTPS for all requests
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+# 2. Force www subdomain (redirect non-www to www)
+RewriteCond %{HTTP_HOST} ^terensys\.fr$ [NC]
+RewriteRule ^(.*)$ https://www.terensys.fr/$1 [R=301,L]
+
+# 3. Remove trailing slashes to prevent self-redirect loops
+# Only if the request is not for a directory
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.+)/$ /$1 [R=301,L]
+
+# 4. Default document handling (if needed)
+DirectoryIndex index.html index.php
+
+# Security headers (optional but recommended)
+<IfModule mod_headers.c>
+    Header always set X-Content-Type-Options nosniff
+    Header always set X-Frame-Options SAMEORIGIN
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+</IfModule>
+
+# IMPORTANT: Remove or comment out any existing rules that look like:
+# RewriteRule ^(.*)$ https://www.terensys.fr/ [R=301,L]
+# These cause the infinite redirect loop

--- a/terensys_diagnostic_report.md
+++ b/terensys_diagnostic_report.md
@@ -1,0 +1,130 @@
+# Diagnostic Report: terensys.fr Website Issues
+
+## Problem Summary
+The terensys.fr website is experiencing multiple critical issues:
+
+1. **Infinite Redirect Loop** on www.terensys.fr
+2. **SSL/TLS Certificate Issues** on terensys.fr (non-www)
+3. **MAXREDIRECTS Errors** when accessing the site
+4. **EPROTO Errors** on the non-www domain
+
+## Detailed Analysis
+
+### 1. Redirect Loop Issue
+**Problem**: `https://www.terensys.fr/` keeps redirecting to itself in an infinite loop.
+
+**Evidence**:
+```
+HTTP/2 301 
+location: https://www.terensys.fr/
+```
+
+**Root Cause**: The server configuration is set to redirect `https://www.terensys.fr/` to `https://www.terensys.fr/` (itself), creating an infinite loop.
+
+### 2. SSL/TLS Certificate Problem
+**Problem**: The non-www domain (`terensys.fr`) has SSL certificate issues.
+
+**Evidence**:
+```
+TLS connect error: error:0A000438:SSL routines::tlsv1 alert internal error
+```
+
+**Root Cause**: SSL certificate configuration issue on the server.
+
+### 3. Server Configuration
+**Server Stack Detected**:
+- Caddy (reverse proxy)
+- Apache/2.4.52 (Ubuntu) (backend server)
+- IP Address: 188.165.192.106
+
+## Solutions
+
+### Immediate Fixes Required
+
+#### 1. Fix Redirect Loop
+**Problem**: Apache/.htaccess or server configuration causing self-redirect
+
+**Solution**: Update the server configuration to either:
+- Remove the redirect rule that's causing the loop
+- Redirect to a different URL (e.g., specific landing page)
+- Set up proper canonical URL handling
+
+**Example .htaccess fix**:
+```apache
+# Remove or fix the problematic redirect rule
+# Current (broken):
+# RewriteRule ^(.*)$ https://www.terensys.fr/ [R=301,L]
+
+# Correct approach - redirect to root without trailing slash loop:
+RewriteEngine On
+RewriteCond %{HTTPS} off
+RewriteRule ^(.*)$ https://www.terensys.fr%{REQUEST_URI} [R=301,L]
+
+# Or redirect non-www to www:
+RewriteCond %{HTTP_HOST} !^www\.
+RewriteRule ^(.*)$ https://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+```
+
+#### 2. Fix SSL Certificate
+**Problem**: SSL certificate not properly configured for terensys.fr
+
+**Solutions**:
+- Ensure SSL certificate covers both `terensys.fr` and `www.terensys.fr`
+- Update certificate if it's expired or misconfigured
+- Check Caddy SSL configuration
+
+**Caddy configuration example**:
+```
+terensys.fr, www.terensys.fr {
+    tls your-email@domain.com
+    reverse_proxy localhost:8080
+}
+```
+
+#### 3. Test Different URL Strategies
+**Option A**: Redirect non-www to www
+```apache
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^terensys\.fr [NC]
+RewriteRule ^(.*)$ https://www.terensys.fr/$1 [R=301,L]
+```
+
+**Option B**: Redirect www to non-www
+```apache
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^www\.terensys\.fr [NC]
+RewriteRule ^(.*)$ https://terensys.fr/$1 [R=301,L]
+```
+
+### Testing Commands
+To verify fixes, use these commands:
+
+```bash
+# Test redirect behavior
+curl -I -L --max-redirs 5 https://www.terensys.fr/
+curl -I -L --max-redirs 5 https://terensys.fr/
+
+# Test SSL
+curl -v https://terensys.fr/ 2>&1 | grep -E "(TLS|SSL|certificate)"
+
+# Test final resolution
+curl -s -o /dev/null -w "%{http_code} %{redirect_url} %{num_redirects}\n" https://www.terensys.fr/
+```
+
+## Priority Actions
+1. **High Priority**: Fix the redirect loop on www.terensys.fr
+2. **High Priority**: Fix SSL certificate for terensys.fr
+3. **Medium Priority**: Implement consistent www/non-www strategy
+4. **Low Priority**: Optimize server response times
+
+## Next Steps
+1. Access server configuration files (.htaccess, Caddy config)
+2. Review and fix redirect rules
+3. Update SSL certificate configuration
+4. Test all URL variations
+5. Monitor for 24 hours to ensure stability
+
+---
+*Report generated: $(date)*
+*Server IP: 188.165.192.106*
+*Server: Caddy + Apache/2.4.52 (Ubuntu)*


### PR DESCRIPTION
Provide corrected Apache and Caddy configurations to fix an infinite redirect loop and SSL issues for terensys.fr.

The existing configuration caused an infinite redirect loop, making the website inaccessible, and also presented SSL certificate problems on the non-www domain.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-8795fda8-8605-4992-9bbf-ac693c01d75c) · [Cursor](https://cursor.com/background-agent?bcId=bc-8795fda8-8605-4992-9bbf-ac693c01d75c)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)